### PR TITLE
chore: bump ci and go version

### DIFF
--- a/.github/workflows/ci-run-on-pr.yaml
+++ b/.github/workflows/ci-run-on-pr.yaml
@@ -5,7 +5,7 @@ on:
 
 env:
   # Golang version to use across CI steps
-  GOLANG_VERSION: '1.24'
+  GOLANG_VERSION: '1.25'
 
 permissions:
   contents: read
@@ -80,7 +80,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1.6
+          version: v2.4.0
           args: --verbose
  
   unit-test:

--- a/.github/workflows/ci-run-on-pr.yaml
+++ b/.github/workflows/ci-run-on-pr.yaml
@@ -5,7 +5,7 @@ on:
 
 env:
   # Golang version to use across CI steps
-  GOLANG_VERSION: '1.25'
+  GOLANG_VERSION: '1.24'
 
 permissions:
   contents: read

--- a/.github/workflows/ci-run-on-pr.yaml
+++ b/.github/workflows/ci-run-on-pr.yaml
@@ -5,7 +5,7 @@ on:
 
 env:
   # Golang version to use across CI steps
-  GOLANG_VERSION: '1.24'
+  GOLANG_VERSION: '1.25'
 
 permissions:
   contents: read

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/belastingdienst/opr-paas-crypttool
 
-go 1.24.7
+go 1.25
 
 require (
 	github.com/belastingdienst/opr-paas/v3 v3.3.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/belastingdienst/opr-paas-crypttool
 
-go 1.25
+go 1.24.7
 
 require (
 	github.com/belastingdienst/opr-paas/v3 v3.3.2


### PR DESCRIPTION
correctly bump golangci-lint and go versions to support Go 1.25

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
