### PR TITLE
chore(ci): ensure correct go version is used in workflow

### DIFF
--- a/.github/workflows/build-and-release-binaries.yml
+++ b/.github/workflows/build-and-release-binaries.yml
@@ -4,6 +4,10 @@ on:
     types:
       - published
 
+env:
+  # Golang version to use across CI steps
+  GOLANG_VERSION: '1.25'
+
 jobs:
   binaries:
     runs-on: ubuntu-latest
@@ -15,8 +19,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go
+      - name: Setup Golang
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
 
       - name: Download cyclonedx-gomod
         uses: CycloneDX/gh-gomod-generate-sbom@efc74245d6802c8cefd925620515442756c70d8f # v2.0.0


### PR DESCRIPTION
chore(ci): ensure correct go version is used in workflow

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

workflow uses default go version which is 1.24 and too low

## What is the new behavior?

workflow uses explicit go version, 1.25

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
