### PR TITLE
fix: removing obsolete extension filtering

### DIFF
--- a/internal/convert/convert.go
+++ b/internal/convert/convert.go
@@ -7,10 +7,8 @@ See LICENSE.md for details.
 package convert
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/belastingdienst/opr-paas-cli/v2/internal/paasfile"
@@ -291,19 +289,9 @@ func (s *ConversionService) Reencrypt(
 }
 
 func isPaasObject(filePath string, content []byte) bool {
-	ext := strings.ToLower(filepath.Ext(filePath))
-
 	var data map[string]interface{}
-	var err error
 
-	switch ext {
-	case ".json":
-		err = json.Unmarshal(content, &data)
-	case ".yaml", ".yml":
-		err = yaml.Unmarshal(content, &data)
-	default:
-		return false
-	}
+	err := yaml.Unmarshal(content, &data)
 
 	if err != nil {
 		logrus.Debugf("Failed to parse %s: %v", filePath, err)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 // PathToFileList returns a list of absolute paths to regular files within the given directories.
@@ -46,10 +45,7 @@ func PathToFileList(paths []string) ([]string, error) {
 				return nil
 			}
 
-			ext := strings.ToLower(filepath.Ext(absPath))
-			if ext == ".yaml" || ext == ".yml" || ext == ".json" {
-				files[absPath] = true
-			}
+			files[absPath] = true
 
 			return nil
 		})


### PR DESCRIPTION

## Pull Request type


Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

We currently filter on extension, which not only is a very Windows way, but also is very poorly documented.

## What is the new behavior?

I removed al the filtering and all still works.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

