### PR TITLE
fix: restore NewCryptFromKeys backward compatibility

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -102,7 +102,7 @@ func generateCmd() *cobra.Command {
 	flags.StringVarP(&privateKeyFile, argNamePrivateKeyFile, "p", "", "The file to write the private key to")
 	flags.StringVarP(&publicKeyFile, argNamePublicKeyFile, "P", "", "The file to write the public key to")
 	flags.StringVarP(&outputFormat, argNameOutputFormat, "o", "",
-		"The output format (leave empty not to print to stdout)")
+		"The output format (leave empty to use the default)")
 	flags.StringVarP(&encryptionSecretName, argNameEncSecretName, "S", "",
 		"The name of the secret conating the encryption keys (leave empty to use from PaasConfig)")
 

--- a/pkg/crypt/crypt.go
+++ b/pkg/crypt/crypt.go
@@ -63,20 +63,40 @@ func NewCryptFromFiles(privateKeyPaths []string, publicKeyPath string, encryptio
 	}, nil
 }
 
-// NewCryptFromKeys returns a Crypt based on the provided privateKeys and publicKey (from memory) using the
-// encryptionContext
-func NewCryptFromKeys(privateKeys PrivateKeys, publicKey *rsa.PublicKey, encryptionContext string) (*Crypt, error) {
-	if publicKey == nil {
-		var err error
-		if publicKey, err = privateKeys.PublicKey(); err != nil {
-			return nil, err
-		}
+// NewCryptFromKeys returns a Crypt based on the provided privateKeys and publicKey using the encryptionContext.
+//
+// publicKey accepts the historical public key path string argument, a *rsa.PublicKey for in-memory keys, or nil
+// to derive the public key from the private keys.
+func NewCryptFromKeys(privateKeys PrivateKeys, publicKey any, encryptionContext string) (*Crypt, error) {
+	publicKeyValue, err := resolvePublicKey(privateKeys, publicKey)
+	if err != nil {
+		return nil, err
 	}
+
 	return &Crypt{
 		privateKeys:       privateKeys,
-		publicKey:         publicKey,
+		publicKey:         publicKeyValue,
 		encryptionContext: []byte(encryptionContext),
 	}, nil
+}
+
+func resolvePublicKey(privateKeys PrivateKeys, publicKey any) (*rsa.PublicKey, error) {
+	switch value := publicKey.(type) {
+	case nil:
+		return nil, nil
+	case *rsa.PublicKey:
+		if value == nil {
+			return nil, nil
+		}
+		return value, nil
+	case string:
+		if value == "" {
+			return nil, nil
+		}
+		return readPublicKeyFromDisk(value)
+	default:
+		return nil, fmt.Errorf("unsupported public key type %T", publicKey)
+	}
 }
 
 // NewGeneratedCrypt generates a new Crypt instance with randomly generated private

--- a/pkg/crypt/crypt_test.go
+++ b/pkg/crypt/crypt_test.go
@@ -94,3 +94,95 @@ func TestCrypt(t *testing.T) {
 	require.NoError(t, err, "Decrypting with other context")
 	assert.Equal(t, original, string(decrypted))
 }
+
+func TestNewCryptFromKeysWithPublicKeyPath(t *testing.T) {
+	context := "context"
+	original := "Dit is een test"
+
+	priv, err := os.CreateTemp("", "private")
+	require.NoError(t, err, "Creating tempfile for private key")
+	defer os.Remove(priv.Name()) // clean up
+
+	pub, err := os.CreateTemp("", "public")
+	require.NoError(t, err, "Creating tempfile for public key")
+	defer os.Remove(pub.Name()) // clean up
+
+	_, err = NewGeneratedCrypt(priv.Name(), pub.Name(), context)
+	require.NoError(t, err, "Generating keys")
+
+	privateKeys, err := NewPrivateKeysFromFiles([]string{priv.Name()})
+	require.NoError(t, err, "Reading private key")
+
+	c, err := NewCryptFromKeys(privateKeys, pub.Name(), context)
+	require.NoError(t, err, "Getting New Crypt from public key path")
+
+	encrypted, err := c.Encrypt([]byte(original))
+	require.NoError(t, err, "Encrypting")
+
+	decrypted, err := c.Decrypt(encrypted)
+	require.NoError(t, err, "Decrypting")
+	assert.Equal(t, original, string(decrypted))
+}
+
+func TestNewCryptFromKeysWithEmptyPublicKeyPath(t *testing.T) {
+	context := "context"
+
+	priv1, err := os.CreateTemp("", "private1")
+	require.NoError(t, err, "Creating tempfile for first private key")
+	defer os.Remove(priv1.Name()) // clean up
+
+	pub1, err := os.CreateTemp("", "public1")
+	require.NoError(t, err, "Creating tempfile for first public key")
+	defer os.Remove(pub1.Name()) // clean up
+
+	priv2, err := os.CreateTemp("", "private2")
+	require.NoError(t, err, "Creating tempfile for second private key")
+	defer os.Remove(priv2.Name()) // clean up
+
+	pub2, err := os.CreateTemp("", "public2")
+	require.NoError(t, err, "Creating tempfile for second public key")
+	defer os.Remove(pub2.Name()) // clean up
+
+	_, err = NewGeneratedCrypt(priv1.Name(), pub1.Name(), context)
+	require.NoError(t, err, "Generating first key")
+	_, err = NewGeneratedCrypt(priv2.Name(), pub2.Name(), context)
+	require.NoError(t, err, "Generating second key")
+
+	privateKeys, err := NewPrivateKeysFromFiles([]string{priv1.Name(), priv2.Name()})
+	require.NoError(t, err, "Reading private keys")
+
+	c, err := NewCryptFromKeys(privateKeys, "", context)
+	require.NoError(t, err, "Getting New Crypt without public key")
+	assert.NotNil(t, c)
+	assert.Nil(t, c.publicKey)
+}
+
+func TestNewCryptFromKeysWithNilPublicKey(t *testing.T) {
+	context := "context"
+	original := "Dit is een test"
+
+	priv, err := os.CreateTemp("", "private")
+	require.NoError(t, err, "Creating tempfile for private key")
+	defer os.Remove(priv.Name()) // clean up
+
+	pub, err := os.CreateTemp("", "public")
+	require.NoError(t, err, "Creating tempfile for public key")
+	defer os.Remove(pub.Name()) // clean up
+
+	_, err = NewGeneratedCrypt(priv.Name(), pub.Name(), context)
+	require.NoError(t, err, "Generating keys")
+
+	privateKeys, err := NewPrivateKeysFromFiles([]string{priv.Name()})
+	require.NoError(t, err, "Reading private key")
+
+	c, err := NewCryptFromKeys(privateKeys, nil, context)
+	require.NoError(t, err, "Getting New Crypt without public key")
+	assert.Nil(t, c.publicKey)
+
+	encrypted, err := c.Encrypt([]byte(original))
+	require.NoError(t, err, "Encrypting with public key derived from private key")
+
+	decrypted, err := c.Decrypt(encrypted)
+	require.NoError(t, err, "Decrypting")
+	assert.Equal(t, original, string(decrypted))
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`NewCryptFromKeys` no longer accepts the previous public key path string argument. This breaks downstream consumers that still pass an empty string to indicate that no public key path is provided.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Restores backward compatibility for `NewCryptFromKeys`.
- Supports the previous string public key path argument, including an empty string.
- Keeps support for in-memory `*rsa.PublicKey` values.
- Treats `nil` and an empty string as no public key provided, relying on existing lazy public key lookup when encryption needs it.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->